### PR TITLE
Support simple C++ linters

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -1,3 +1,5 @@
+# Changed 2020 by Zenseact AB
+
 LinterInfo = provider(
     fields = {
         "executable_path": "Absolute path to the linter that will run",
@@ -13,7 +15,7 @@ def _linter_impl(ctx):
     return [
         LinterInfo(
             executable_path=ctx.attr.executable_path,
-            executable=ctx.executable.executable,
+            executable=ctx.attr.executable,
             config=ctx.file.config,
             config_option=ctx.attr.config_option,
             config_str=ctx.attr.config_str,

--- a/rules.bzl
+++ b/rules.bzl
@@ -16,7 +16,7 @@ def _linter_impl(ctx):
         LinterInfo(
             executable_path=ctx.attr.executable_path,
             executable=ctx.attr.executable,
-            config=ctx.file.config,
+            config=ctx.attr.config,
             config_option=ctx.attr.config_option,
             config_str=ctx.attr.config_str,
         )
@@ -36,7 +36,7 @@ linter = rule(
             doc="Label for an executable linter",
         ),
         "config": attr.label(
-            allow_single_file=True,
+            allow_files=True,
             doc="Configuration file for linter",
         ),
         "config_option": attr.string(


### PR DESCRIPTION
Support basic C++ linters/formatters, such as clang-format or cpplint.
Tools that require a compile-commands.json are not yet in scope.

Clang-format will insist that the configuration file is called
".clang-format" and that it resides in a parent directory, and will
not tolerate any mention of the file on the command line. It wants the
`"-i"` flag to format code in place. To accomodate this, permit
specifying both config_str and config, and don't mention the config
file on the command line unless config_opt is specified. In the
clang-format case, you would run with `config_str="-i"` and
`config="//.clang-format"` (to bring the file into the sandbox).