### PR TITLE
🐛 If a linter is configured with 'executable_path' we cannot call .resolve_tools on it

### DIFF
--- a/generator.bzl
+++ b/generator.bzl
@@ -155,7 +155,12 @@ def _lint_workspace_aspect_impl(target, ctx):
         is_executable = True,
     )
 
-    tool_inputs, tool_input_manifests = ctx.resolve_tools(tools = [linter[LinterInfo].executable])
+    # If the linter exe is configured with `executable_path`, eg. `executable_path = "/usr/local/bin/black"`,
+    # do not attempt to resolve `executable` as it will be `None` not a `Target` object.
+    tool_inputs = []
+    tool_input_manifests = None
+    if linter[LinterInfo].executable:
+        tool_inputs, tool_input_manifests = ctx.resolve_tools(tools = [linter[LinterInfo].executable])
 
     ctx.actions.run(
         outputs = outputs + [report_out],


### PR DESCRIPTION
Pull request https://github.com/thundergolfer/bazel-linting-system/pull/14 changed how linters configured using the `linter.executable` attr worked, which broke linters using the `linter.executable_path` attribute.

**Example error:**

```bash
Running 'build' phase of bazel-linting-system...
INFO: Invocation ID: ad226ebb-f640-4f24-8fe4-d07c627b99f5
ERROR: /Users/jonathon/Code/thundergolfer/example-bazel-monorepo/py_antilibrary/BUILD:11:11: in //tools/linting:aspect.bzl%lint aspect on py_library rule //py_antilibrary:py_antilibrary:
Traceback (most recent call last):
	File "/private/var/tmp/_bazel_jonathon/06ae70e3a686adbadc5f109e3045a096/external/linting_system/generator.bzl", line 158, column 58, in _lint_workspace_aspect_impl
		tool_inputs, tool_input_manifests = ctx.resolve_tools(tools = [linter[LinterInfo].executable])
Error in resolve_tools: at index 0 of tools, got element of type NoneType, want Target
ERROR: Analysis of aspect '//tools/linting:aspect.bzl%lint of //py_antilibrary:py_antilibrary' failed; build aborted: Analysis of target '//py_antilibrary:py_antilibrary' failed
INFO: Elapsed time: 0.444s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (4 packages loaded, 4 targets configured)
    currently loading: @local_config_sh//
```

By conditionally calling the `ctx.resolve_tools` function (and passing in correct 'empty' vals if not calling it) `linter.executable_path` linters work again. 